### PR TITLE
Fix 2 Unit tests

### DIFF
--- a/dev/katari-hibernate/src/test/java/com/globant/katari/hibernate/coreuser/domain/CoreUserRepositoryTest.java
+++ b/dev/katari-hibernate/src/test/java/com/globant/katari/hibernate/coreuser/domain/CoreUserRepositoryTest.java
@@ -3,6 +3,7 @@
 package com.globant.katari.hibernate.coreuser.domain;
 
 import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
@@ -16,7 +17,7 @@ public class CoreUserRepositoryTest {
   /** Creates a sample user named test.
    */
   @Before
-  protected void setUp() throws Exception {
+  public void setUp() throws Exception {
     userRepository = (CoreUserRepository) SpringTestUtils.get().getBean(
         "coreuser.userRepository");
     userRepository.getHibernateTemplate().bulkUpdate("delete from CoreUser");
@@ -24,12 +25,13 @@ public class CoreUserRepositoryTest {
     userRepository.getHibernateTemplate().save(user);
   }
 
+  @Test
   public void testFindUserByName() throws Exception {
     CoreUser user = userRepository.findUserByName("test");
-    assertThat(user, is(nullValue()));
     assertThat(user.getName(), is("test"));
   }
 
+  @Test
   public void testFindUser() throws Exception {
     CoreUser user = userRepository.findUserByName("test");
     long id = user.getId();

--- a/dev/katari-user/src/test/java/com/globant/katari/user/application/UserFilterCommandTest.java
+++ b/dev/katari-user/src/test/java/com/globant/katari/user/application/UserFilterCommandTest.java
@@ -46,7 +46,7 @@ public class UserFilterCommandTest {
   /* Adds a pair of users to be used in the tests.
    */
   private void addUsers() {
-
+    SpringTestUtils.beginTransaction();
     //  Removes the unneeded users.
     while (userRepository.getUsers(new UserFilter()).size() != 0) {
       for (User user : userRepository.getUsers(new UserFilter())) {
@@ -74,6 +74,7 @@ public class UserFilterCommandTest {
     user = new User("ramon", "ramon@none");
     user.changePassword("pass");
     userRepository.save(user);
+    SpringTestUtils.endTransaction();
   }
 
   /* Test Execute.


### PR DESCRIPTION
In mac,the user filter test fails because of two open sessions exception.
What I did is basically, start and close a tx everty time we create and deletes the users.
